### PR TITLE
changed 'Reset' button type to reset and cleaned css.

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@
                         <input type="text" id="password" name="password" placeholder="">
                     </div>
                     <div class="buttons">
-                        <button type="submit">Reset</button>
+                        <button type="reset">Reset</button>
                         <button type="submit">Submit</button>
                     </div>
                 </form>

--- a/style.css
+++ b/style.css
@@ -1,9 +1,8 @@
 
-.body{
-    width: 1440px;
-    height: 617px;
-    left: 0px;
-    top: 407px;
+body{
+    width: 100vw;
+    margin: 0; 
+    box-sizing: border-box;
 }
 .flex-container{
     font-family: Verdana, Geneva, Tahoma, sans-serif;
@@ -63,8 +62,6 @@
     float: right;
     width: 233px;
     height: 35px;
-    left: 290px;
-    top: 314px;
     background: #FBFBFB;
     border: 1px solid #000000;
     border-radius: 3px;
@@ -73,13 +70,9 @@
     display: flex;
     flex-direction: row;
     align-items: flex-start;
-    padding: 0px;
     gap: 25px;
     width: 443px;
     height: 55px;
-    left: 107px;
-    top: 485px;
-    border-radius: 2px;
     padding: 8px;
 }
 button{
@@ -88,9 +81,6 @@ button{
     background: #328EFA;
     border-radius: 15px;
     font-size: 1.2rem;
-    flex: none;
-    order: 0;
-    flex-grow: 0;
 }
 .footer{
     align-self: end;


### PR DESCRIPTION
## Description

1. Changed 'Reset' button type to reset. It will reset word form when clicked.
2. Removed . before 'body' and cleaned unnecessary code from CSS.

## Related Issue

<!-- If you write "closes" followed by the Github issue number, it will automatically close the issue for you when the PR merges -->

## Acceptance Criteria

<!-- Include AC from the Github issue -->

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|   ✓ | :bug: Bug fix              |
|     | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

index.html
style.css

### Before

<!-- If UI feature, take provide screenshots -->

### After

<!-- If UI feature, take provide screenshots -->

## Testing Steps / QA Criteria

<!-- Provide steps needed to follow to properly test your additions. -->
